### PR TITLE
Move "Annotations on classes and constructors" out of the introduction

### DIFF
--- a/docs/manual/advanced-features.tex
+++ b/docs/manual/advanced-features.tex
@@ -554,6 +554,93 @@ misbehave at run time.
 % annotations for type system designers.
 
 
+\newpage
+
+\sectionAndLabel{Annotations on classes and constructors}{annotations-on-classes-and-constructors}
+
+\subsectionAndLabel{Annotations on class declarations}{annotations-on-class-declarations}
+
+% TODO: use a more realistic example.
+
+Writing an annotation on a class declaration makes that annotation implicit
+for all uses of the class (see Section~\ref{effective-qualifier}).
+That is, the annotation is an upper bound for all uses of the type.
+
+Consider the type hierarchy \code{@A :> @B :> @C} and the following
+declaration:
+
+\begin{Verbatim}
+@B class MyClass { ... }
+\end{Verbatim}
+
+\noindent
+Every unannotated use of \<MyClass> is \<@B MyClass>, and every use of
+\<MyClass> must be a subtype of \<@B> --- that is, \<@A MyClass> is not a
+valid type, but \<@C MyClass> is valid.
+
+
+\subsectionAndLabel{Annotations on constructor declarations}{annotations-on-constructor-declarations}
+
+An annotation on the ``return type'' of a constructor declaration indicates
+what the constructor creates.  For example,
+
+\begin{Verbatim}
+@B class MyClass {
+  @C MyClass() {}
+}
+\end{Verbatim}
+
+\noindent
+means that invoking that constructor creates a \<@C MyClass>.
+
+The Checker Framework cannot verify that the constructor really creates
+such an object, because the Checker Framework does not know the
+type-system-specific semantics of the \<@C> annotation.
+Therefore, if the constructor result type is different than the top annotation in the
+hierarchy, the Checker Framework will issue a warning.
+The programmer should check the annotation manually, then
+suppress the warning.
+
+
+\subsubsectionAndLabel{Defaults}{constructor-declaration-defaults}
+
+If a constructor declaration is unannotated, it defaults to the same type as that of
+its enclosing class (rather than the default qualifier in the hierarchy).
+For example, the Tainting Checker (Chapter~\ref{tainting-checker}) has \code{@Tainted}
+as its default qualifier. Consider the following class:
+
+\begin{Verbatim}
+  @Untainted class MyClass {
+    MyClass() {}
+  }
+\end{Verbatim}
+
+\noindent
+The constructor declaration is equivalent to \<@Untainted MyClass() \ttlcb\ttrcb>.
+
+The Checker Framework produces the same error messages for
+explicitly-written and defaulted annotations.
+
+
+\subsectionAndLabel{Annotations on constructor invocations}{annotations-on-constructor-invocations}
+
+The type of a method call expression \<x.myMethod(y, z)> is determined by
+the return type of the declaration of \<myMethod>.  There is no way to
+write an annotation on the call to change its type.  However, it is
+possible to write a cast:  \<(@Anno SomeType) x.myMethod(y, z)>.  The Checker
+Framework will issue a warning that it cannot verify that the downcast is
+correct.  The programmer should manually determine that the annotation is
+correct and then suppress the warning.
+
+A constructor invocation \<new MyClass()> is also a call, so its semantics
+are similar.  The type of the expression is determined by the annotation on
+the result type of the constructor declaration.  It is possible to write a cast
+\<(@Anno MyClass) new MyClass()>.  The syntax \<new @Anno MyClass()> is shorthand
+for the cast.  For either syntax, the Checker Framework will issue a
+warning that it cannot verify that the cast is correct.  The programmer may
+suppress the warning if the code is correct.
+
+
 \sectionAndLabel{Automatic type refinement (flow-sensitive type qualifier inference)}{type-refinement}
 
 The
@@ -1491,4 +1578,4 @@ class @Marsupial-Animal {
 %%  LocalWords:  AuseDefaultsForUncheckedCode DefaultFor TypeUseLocation
 % LocalWords:  AuseDefaultsForUncheckedcode EnsuresKeyFor EnsuresKeyForIf
 % LocalWords:  EnsuresLockHeld EnsuresLockHeldIf FieldInvariant fieldA
-% LocalWords:  fieldB
+% LocalWords:  fieldB myMethod SomeType

--- a/docs/manual/introduction.tex
+++ b/docs/manual/introduction.tex
@@ -1284,61 +1284,6 @@ able to do more precise checking, than if line 141 has an annotation.
 It is a pleasant feature of the Checker Framework that in many cases, no
 annotations at all are needed on type parameters such as \code{E} in \<MultiSet>.
 
-\subsectionAndLabel{Annotations on constructor declarations}{annotations-on-constructor-declarations}
-
-If a constructor declaration is unannotated, it defaults to the same type as that of
-its enclosing class (rather than the default qualifier in hierarchy).
-For example: the Tainting Checker (Chapter~\ref{tainting-checker}) has \code{@Tainted}
-as its default qualifier. Consider the following class:
-
-\begin{Verbatim}
-  @Untainted class MyClass {
-    MyClass() {}
-  }
-\end{Verbatim}
-
-The constructor declaration is equivalent to \<@Untainted MyClass() \ttlcb\ttrcb>.
-
-\subsectionAndLabel{Annotations on classes and
-  constructors}{annotations-on-classes-and-constructors}
-
-% TODO: use a more realistic example.
-
-Writing an annotation on a class declaration makes that annotation implicit
-for all uses of the class (see Section~\ref{effective-qualifier}).
-Consider the type hierarchy \code{@A :> @B :> @C :> @D} and the following
-declaration:
-
-\begin{Verbatim}
-@B class MyClass { ... }
-\end{Verbatim}
-
-Every unannotated use of \<MyClass> is \<@B MyClass>, and every use of
-\<MyClass> must be a subtype of \<@B> --- that is, \<@A MyClass> is not a
-valid type, but \<@C MyClass> is valid.
-
-An annotation on the ``return type'' of a constructor declaration indicates
-what the constructor creates.  For example,
-
-\begin{Verbatim}
-@B class MyClass {
-  @C MyClass() {}
-}
-\end{Verbatim}
-
-\noindent
-means that invoking that constructor creates a \<@C MyClass>.  The Checker
-Framework cannot verify that the constructor really creates such an object,
-so it issues a warning.  The programmer should suppress the warning, if the
-programmer is sure the annotation sound.
-
-An annotation on a constructor invocation is equivalent to a cast on a
-constructor result.  For example, \<new @D MyClass()> is equivalent to writing
-\<(@D MyClass) new MyClass()>.  Since this is a downcast from the declared
-type of \<@C>, the Checker Framework will issue a warning.  As above, the
-programmer should manually determine that the annotation is valid and then
-suppress the warning.
-
 
 \subsectionAndLabel{What to do if a checker issues a warning about your code}{handling-warnings}
 


### PR DESCRIPTION
This does not repeat all of the type rules.
Having those in one place would be useful, but feels like it belongs in developer documentation rather than being enumerated in the user manual.