### PR TITLE
Update CHANGELOG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ local.properties
 api
 build
 dist
+docs/CHANGELOG.html
 docs/tmpapi/
 stubparser/docs/api
 # Don't want to ignore .jar files in checker/lib/ nor in gradle/wrapper

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -179,7 +179,7 @@ Version 3.32.0 (March 2, 2023)
 Fixed a bug in the Nullness Checker where a call to a side-effecting method did
 not make some formal parameters possibly-null.  The Nullness Checker is likely
 to issue more warnings for your code.  For ways to eliminate the new warnings,
-see https://checkerframework.org/manual/#type-refinement-side-effects .
+see <https://checkerframework.org/manual/#type-refinement-side-effects> .
 
 If you supply the `-AinvocationPreservesArgumentNullness` command-line
 option, the Nullness Checker unsoundly assumes that arguments passed to
@@ -683,7 +683,7 @@ Version 3.13.0 (May 3, 2021)
 If you use the Checker Framework, please answer a 3-question survey about what
 version of Java you use.  It will take less than 1 minute to complete.  Please
 answer it at
-https://docs.google.com/forms/d/1Bbt34c_3nDItHsBnmEfumoyrR-Zxhvo3VTHucXwfMcQ .
+<https://docs.google.com/forms/d/1Bbt34c_3nDItHsBnmEfumoyrR-Zxhvo3VTHucXwfMcQ> .
 Thanks!
 
 **User-visible changes:**
@@ -1733,7 +1733,7 @@ Added a @QualifierArgument annotation to be used on pre- and postcondition
 Added new type @InternalFormForNonArray to the Signature Checker
 
 Moved annotated libraries from checker/lib/*.jar to the Maven Central Repository:
-https://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.checkerframework.annotatedlib%22
+<https://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.checkerframework.annotatedlib%22>
 
 Moved the Javadoc stub file from checker/lib/javadoc.astub to
 checker/resources/javadoc.astub.
@@ -1916,7 +1916,7 @@ get the conservative behavior.
 Version 2.1.8 (20 January 2017)
 -------------------------------
 
-The Checker Framework webpage has moved to https://checkerframework.org/.
+The Checker Framework webpage has moved to <https://checkerframework.org/>.
 Old URLs should redirect to the new one, but please update your links
 and let us know if any old links are broken rather than redirecting.
 
@@ -2080,7 +2080,7 @@ Documentation improvements:
 Tool changes:
 
  * The Checker Framework Live Demo webpage lets you try the Checker
-   Framework without installing it:  http://eisop.uwaterloo.ca/live/
+   Framework without installing it:  <http://eisop.uwaterloo.ca/live/>
 
  * New command-line arguments -Acfgviz and -Averbosecfg enable better
    debugging of the control-flow-graph generation step of type-checking.
@@ -2165,17 +2165,17 @@ Documentation:
  * Documented how to initialize circular data structures in the
    Initialization type system.
  * Linked to David Bürgin's Nullness Checker tutorial at
-   https://github.com/glts/safer-spring-petclinic/wiki
+   <https://github.com/glts/safer-spring-petclinic/wiki>
  * Acknowledged more contributors in the manual.
 
 For type-system developers:
  * The org.checkerframework.framework.qual.TypeQualifier{s} annotations are
    now deprecated.  To indicate which annotations a checker supports, see
-   https://checkerframework.org/manual/#creating-indicating-supported-annotations .
+   <https://checkerframework.org/manual/#creating-indicating-supported-annotations> .
    Support for TypeQualifier{s} will be removed in the next release.
  * Renamed
-   org.checkerframework.framework.qual.Default{,Qualifier}ForUnannotatedCode to
-   DefaultInUncheckedCodeFor and DefaultQualifierInHierarchyInUncheckedCode.
+   `org.checkerframework.framework.qual.Default{,Qualifier}ForUnannotatedCode` to
+   `DefaultInUncheckedCodeFor and DefaultQualifierInHierarchyInUncheckedCode`.
 
 **Closed issues:**
 #169, #363, #448, #478, #496, #516, #529.
@@ -2244,7 +2244,9 @@ Moved the Checker Framework version control repository from Google Code to
 GitHub, and from the Mercurial version control system to Git.  If you have
 cloned the old repository, then discard your old clone and create a new one
 using this command:
+```
   git clone https://github.com/typetools/checker-framework.git
+```
 
 Fixed issues:  #427, #429, #434, #442, #450.
 
@@ -2769,7 +2771,7 @@ Adapt to underlying jsr308-langtools changes.
   JDK 7 is now required.  The Checker Framework does not build or run on JDK 6.
 
 Documentation:
-  A new tutorial is available at https://checkerframework.org/tutorial/
+  A new tutorial is available at <https://checkerframework.org/tutorial/>
 
 
 Version 1.5.0 (14 Jan 2013)
@@ -3252,7 +3254,7 @@ Manual:
   of the method and the inferred or explicit method type arguments.
   If you override this method, you will need to update your version.
   See this change set for a simple example:
-  https://github.com/typetools/checker-framework/source/detail?r=8381a213a4
+  <https://github.com/typetools/checker-framework/source/detail?r=8381a213a4>
 
 - Testing framework:
   Support for multiple expected errors using the "// :: A :: B :: C" syntax.
@@ -4087,7 +4089,7 @@ Manual
     8  Annotating libraries
     9  How to create a new checker plugin
   Javadoc for the Checker Framework is included in its distribution and is
-    available online at https://checkerframework.org/api/ .
+    available online at <https://checkerframework.org/api/> .
 
 
 Version 0.6.4 (9 June 2008)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -74,8 +74,8 @@ As an example, for the Nullness Checker,
 
  * `<@NonNull T extends Object>`: change to `<@NonNull T extends @NonNull Object>`
  * `<@NonNull T extends @Nullable Object>`: change to `<@NonNull T>` for better style
- * `<@NonNull T extends @NonNull Object>`: do not change
- * `<@NonNull T>`: do not change
+ * `<@NonNull T extends @NonNull Object>`: don't change
+ * `<@NonNull T>`: don't change
 
  * `<? extends Object>`: change to `<@NonNull ?>`
  * `<? extends @Nullable Object>`: change to `<?>` for better style
@@ -90,7 +90,7 @@ As an example, for the Nullness Checker,
  * `<@NonNull ? extends Object>`: change to `<@NonNull ?>`
  * `<@NonNull ? extends @Nullable Object>`: change to `<@NonNull ?>` for better style
  * `<@NonNull ? extends @NonNull Object>`: change to `<@NonNull ?>` for better style
- * `<@NonNull ?>`: do not change
+ * `<@NonNull ?>`: don't change
 
 
 As another example, for the Signedness Checker,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -64,6 +64,9 @@ extends @Anno Object>`" cannot be abbreviated unless `@Anno` is the top type, in
 which case it is equivalent to "`<@Anno T>`".  "`<T>`" is equivalent to
 "<code>&lt;@<em>BottomType</em> T extends @<em>TopType</em> Object&gt;</code>".
 
+For more details about the meaning of generic types, see the manual section
+["Syntax for upper and lower
+bounds"](https://checkerframework.org/manual/#generics-bounds-syntax).
 
 As an example, for the Nullness Checker,
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -61,7 +61,8 @@ For wildcards, the same transformations apply, with one exception.  "`<@Anno ?
 extends @Anno Object>`" can be abbreviated "`<@Anno ?>`", but the same
 abbreviation does not apply to non-wildcard type variables.  That is, "`<@Anno T
 extends @Anno Object>`" cannot be abbreviated unless `@Anno` is the top type, in
-which case it is equivalent to just "`<T>`".
+which case it is equivalent to "`<@Anno T>`".  "`<T>`" is equivalent to
+"<code>&lt;@<em>BottomType</em> T extends @<em>TopType</em> Object&gt;</code>".
 
 
 As an example, for the Nullness Checker,
@@ -72,14 +73,14 @@ As an example, for the Nullness Checker,
  * `<T>`: don't change
 
  * `<@Nullable T extends Object>`: did not make sense (and has a different meaning now)
- * `<@Nullable T extends @Nullable Object>`: change to `<T>` for better style
+ * `<@Nullable T extends @Nullable Object>`: change to `<@Nullable T>` for better style
  * `<@Nullable T extends @NonNull Object>`: did not make sense, and still doesn't
- * `<@Nullable T>`: change to `<T>` for better style
+ * `<@Nullable T>`: don't change
 
  * `<@NonNull T extends Object>`: change to `<@NonNull T extends @NonNull Object>`
- * `<@NonNull T extends @Nullable Object>`: change to `<@NonNull T>` for better style
- * `<@NonNull T extends @NonNull Object>`: don't change
- * `<@NonNull T>`: don't change
+ * `<@NonNull T extends @Nullable Object>`: change to `<T>` for better style
+ * `<@NonNull T extends @NonNull Object>`: change to `<T extends @NonNull Object>` for better style
+ * `<@NonNull T>`: change to `<T>`
 
  * `<? extends Object>`: change to `<@NonNull ?>`
  * `<? extends @Nullable Object>`: change to `<?>` for better style
@@ -87,12 +88,12 @@ As an example, for the Nullness Checker,
  * `<?>`: don't change
 
  * `<@Nullable ? extends Object>`: did not make sense (and has a different meaning now)
- * `<@Nullable ? extends @Nullable Object>`: change to `<?>` for better style
+ * `<@Nullable ? extends @Nullable Object>`: change to `<?>`
  * `<@Nullable ? extends @NonNull Object>`: did not make sense, and still doesn't
- * `<@Nullable ?>`: change to `<?>` for better style
+ * `<@Nullable ?>`: don't change
 
  * `<@NonNull ? extends Object>`: change to `<@NonNull ?>`
- * `<@NonNull ? extends @Nullable Object>`: change to `<@NonNull ?>` for better style
+ * `<@NonNull ? extends @Nullable Object>`: change to `<?>`
  * `<@NonNull ? extends @NonNull Object>`: change to `<@NonNull ?>` for better style
  * `<@NonNull ?>`: don't change
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,16 +19,16 @@ Previously, the Checker Framework interpreted
 Now, the Checker Framework interprets
 `class MyClass<T extends Object>` as
 `class MyClass<T extends @TopType Object>`.
-There is no change when the upper bound is not `Object`;
+There is no change when the upper bound is not `Object`; for example,
 `class MyClass<T extends Number>` is still treated as
 `class MyClass<T extends @DefaultType Number>`.
 
 This means that the Checker Framework now treats
-`class MyClass<T>` and `class MyClass<T extends Object>` identically:
-in both cases, instantiation is permitted by any (annotated) client type.
+`class MyClass<T>` and `class MyClass<T extends Object>` identically:  in both
+cases, instantiation is permitted by any client type, regardless of annotations.
 This change leads to fewer annotations and less effort for type systems where
 the default type qualifier is not the top type qualifier (listed at
-https://checkerframework.org/manual/#default-is-not-top-type-systems).
+<https://checkerframework.org/manual/#default-is-not-top-type-systems>).
 
 No code changes are required for type systems that default explicit and implicit
 bounds the same, such as the Locking Checker, even though its default type

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -57,7 +57,11 @@ Make the following changes:
    but leave "<code>&lt;T extends @<em>TopType1 NotTopType2</em> Object&gt;</code>"
    unchanged.)
 
-For wildcards, the same transformations apply.
+For wildcards, the same transformations apply, with one exception.  "`<@Anno ?
+extends @Anno Object>`" can be abbreviated "`<@Anno ?>`", but the same
+abbreviation does not apply to non-wildcard type variables.  That is, "`<@Anno T
+extends @Anno Object>`" cannot be abbreviated unless `@Anno` is the top type, in
+which case it is equivalent to just "`<T>`".
 
 
 As an example, for the Nullness Checker,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,9 @@ qualifer is not the top type qualifier.
 
 If the default type qualifier differs from the top type qualifier, you need to
 update some code and annotated libraries,
+
+[//]: # (Comment: GitHub Markdown does not render the italics, but other Markdown engines do.)
+
  * change `<... extends Object>` to <code>&lt;... extends @<em>DefaultType</em> Object&gt;</code>.
    If your code contains `<... extends Object>` where arbitrary instantiation is
    desirable, then your previous annotations were buggy and should have been
@@ -3273,7 +3276,7 @@ Property File Checker (new):
 
 Signature Checker (new):
   Ensures that different string representations of a Java type (e.g.,
-  "pakkage.Outer.Inner" vs. "pakkage.Outer$Inner" vs. "Lpakkage/Outer$Inner;")
+  `"pakkage.Outer.Inner"` vs. `"pakkage.Outer$Inner"` vs. `"Lpakkage/Outer$Inner;"`)
   are not misused.
 
 Interning Checker enhancements:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,7 +32,7 @@ the default type qualifier is not the top type qualifier (listed at
 
 No code changes are required for type systems that default explicit and implicit
 bounds the same, such as the Locking Checker, even though its default type
-qualifer is not the top type qualifier.
+qualifier is not the top type qualifier.
 
 If the default type qualifier differs from the top type qualifier, you need to
 update some code and annotated libraries, namely
@@ -61,8 +61,7 @@ For wildcards, the same transformations apply, with one exception.  "`<@Anno ?
 extends @Anno Object>`" can be abbreviated "`<@Anno ?>`", but the same
 abbreviation does not apply to non-wildcard type variables.  That is, "`<@Anno T
 extends @Anno Object>`" cannot be abbreviated unless `@Anno` is the top type, in
-which case it is equivalent to "`<@Anno T>`".  "`<T>`" is equivalent to
-"<code>&lt;@<em>BottomType</em> T extends @<em>TopType</em> Object&gt;</code>".
+which case it is equivalent to "`<@Anno T>`".
 
 For more details about the meaning of generic types, see the manual section
 ["Syntax for upper and lower
@@ -91,7 +90,7 @@ As an example, for the Nullness Checker,
  * `<?>`: don't change
 
  * `<@Nullable ? extends Object>`: did not make sense (and has a different meaning now)
- * `<@Nullable ? extends @Nullable Object>`: change to `<?>`
+ * `<@Nullable ? extends @Nullable Object>`: change to `<@Nullable ?>`
  * `<@Nullable ? extends @NonNull Object>`: did not make sense, and still doesn't
  * `<@Nullable ?>`: don't change
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,30 +35,33 @@ bounds the same, such as the Locking Checker, even though its default type
 qualifer is not the top type qualifier.
 
 If the default type qualifier differs from the top type qualifier, you need to
-update some code and annotated libraries,
+update some code and annotated libraries, namely
 
-[//]: # (Comment: GitHub Markdown does not render the italics, but other Markdown engines do.)
-
- * change `<... extends Object>` to <code>&lt;... extends @<em>DefaultType</em> Object&gt;</code>.
-   If your code contains `<... extends Object>` where arbitrary instantiation is
-   desirable, then your previous annotations were buggy and should have been
-   <code>&lt;... extends @<em>TopType</em> Object&gt;</code>,
-   but that can be written as just `<T>`, which is better style.
- * optionally, change <code>&lt;T extends @<em>TopType</em> Object&gt;</code> to just `<T>`.
-   This change is not required, but it is recommended as a matter of style.
-   (If the code is annotated for two type systems, then change
-   <code>&lt;T extends @<em>TopType1 TopType2</em> Object&gt;</code> to `<T>`,
-   but leave <code>&lt;T extends @<em>TopType1 NotTopType2</em> Object&gt;</code>
-   unchanged.)
-
-For wildcards, the same transformations apply.
-
-Make these changes in:
  * every file that is typechecked by a non-default-top type system, and
  * every file that contains `@AnnotatedFor` for a non-default-top type system
    (this is used in annotated libraries).
 
+Make the following changes:
+
+[//]: # (Comment: GitHub Markdown does not render the italics, but other Markdown engines do.)
+
+ * change "`<... extends Object>`" to "<code>&lt;... extends @<em>DefaultType</em> Object&gt;</code>".
+   If your code contains "`<... extends Object>`" where arbitrary instantiation is
+   desirable, then your previous annotations were buggy and should have been
+   "<code>&lt;... extends @<em>TopType</em> Object&gt;</code>",
+   but that can be written as just "`<...>`", which is better style.
+ * optionally, remove <code>extends @<em>TopType</em> Object&gt;</code>.
+   This change is not required, but it is recommended as a matter of style.
+   (If the code is annotated for two type systems, then change
+   "<code>&lt;T extends @<em>TopType1 TopType2</em> Object&gt;</code>" to "`<T>`",
+   but leave "<code>&lt;T extends @<em>TopType1 NotTopType2</em> Object&gt;</code>"
+   unchanged.)
+
+For wildcards, the same transformations apply.
+
+
 As an example, for the Nullness Checker,
+
  * `<T extends Object>`: change to `<T extends @NonNull Object>`
  * `<T extends @Nullable Object>`: change to `<T>` for better style
  * `<T extends @NonNull Object>`: don't change
@@ -1277,11 +1280,11 @@ Version 3.3.0 (April 1, 2020)
 **User-visible changes:**
 
 New command-line options:
-  -Alint=trustArrayLenZero trust @ArrayLen(0) annotations when determining
+  `-Alint=trustArrayLenZero` trust @ArrayLen(0) annotations when determining
   the type of Collections.toArray.
 
 Renamings:
-  -AuseDefaultsForUncheckedCode to -AuseConservativeDefaultsForUncheckedCode
+  `-AuseDefaultsForUncheckedCode` to `-AuseConservativeDefaultsForUncheckedCode`
     The old name works temporarily but will be removed in a future release.
 
 For collection methods with `Object` formal parameter type, such as


### PR DESCRIPTION
The changes may be easier to read at
https://github.com/smillst/checker-framework/blob/explicit-extends-object-changelog/docs/CHANGELOG.md .
